### PR TITLE
Converted decorators to classes due to need for state management

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,17 +30,17 @@ You may only have one consumer per module/service.  A user can publish as much a
 
 ```python
 from typing import TypeVar
-from rabbit_clients import consume_message, publish_message
+from rabbit_clients import PublishMessage, ConsumeMessage
 
 RabbitMQMessage = TypeVar('RabbitMQMessage')
 
 
-@publish_message(queue='younguns')
+@PublishMessage(queue='younguns')
 def publish_to_younguns(message):
     return message
 
 
-@publish_message(queue='aaron_detect')
+@PublishMessage(queue='aaron_detect')
 def check_for_aaron(consumed_message):
     return_message = {'name': consumed_message['name'], 'isAaron': False}
     if return_message['name']  == 'Aaron':
@@ -48,7 +48,7 @@ def check_for_aaron(consumed_message):
     return return_message
 
 
-@consume_message(consume_queue='oldfolks')
+@ConsumeMessage(consume_queue='oldfolks')
 def remove_forty_and_up(message_dict):
     people = message_dict['people']
     not_protected_class = [younger for younger in people if younger['age'] < 40]

--- a/rabbit_clients/__init__.py
+++ b/rabbit_clients/__init__.py
@@ -3,4 +3,5 @@ Init of rabbit_clients package
 
 """
 
-from rabbit_clients.clients.base import publish_message, consume_message
+from rabbit_clients.clients.base import PublishMessage as publish_message, ConsumeMessage as consume_message
+from rabbit_clients.clients.base import PublishMessage, ConsumeMessage

--- a/rabbit_clients/clients/base.py
+++ b/rabbit_clients/clients/base.py
@@ -2,46 +2,34 @@
 Base classes for Rabbit
 
 """
-from typing import Any, NoReturn, Dict, Union, List
+from typing import Any, Dict, Union, List, Tuple
 import os
 import json
 
 import pika
 
-_CONNECTION = None
-_CHANNEL = None
-_HOST = os.getenv('RABBIT_URL', 'localhost')
-_USER = os.getenv('RABBIT_USER', 'guest')
-_PW = os.getenv('RABBIT_PW', 'guest')
+try:
+    from state_manager import PikachuStateManager
+except ImportError:
+    from rabbit_clients.clients.state_manager import PikachuStateManager
 
 
-def _create_global_connection() -> NoReturn:
+def _create_connection_and_channel() -> Tuple[pika.BlockingConnection, pika.BlockingConnection.channel]:
     """
     Will run immediately on library import.  Requires that an environment variable
     for RABBIT_URL has been set.
 
-    :return: None
+    :return: Tuple as rabbitmq connection and channel
+    :rtype: tuple
+
     """
-    global _CONNECTION, _CHANNEL
+    host = os.getenv('RABBIT_URL', 'localhost')
+    user = os.getenv('RABBIT_USER', 'guest')
+    pw = os.getenv('RABBIT_PW', 'guest')
 
-    credentials = pika.PlainCredentials(_USER, _PW)
-    _CONNECTION = pika.BlockingConnection(pika.ConnectionParameters(_HOST, credentials=credentials))
-    _CHANNEL = _CONNECTION.channel()
-
-
-def _check_connection() -> NoReturn:  # pragma: no-cover
-    """
-    Checks to make sure a connection didn't close; reopens everything if true
-
-    :return: None
-    """
-    global _CONNECTION
-
-    if not _CONNECTION:
-        _create_global_connection()
-
-    if not _CONNECTION.is_open:
-        _create_global_connection()
+    credentials = pika.PlainCredentials(user, pw)
+    connection = pika.BlockingConnection(pika.ConnectionParameters(host, credentials=credentials))
+    return connection, connection.channel()
 
 
 def send_log(channel: Any, method: str, properties: Any, body: str) -> Dict[str, Any]:
@@ -63,70 +51,20 @@ def send_log(channel: Any, method: str, properties: Any, body: str) -> Dict[str,
     }
 
 
-def publish_message(queue: str, exchange: str = '') -> Any:
-    """
-    Send a message to the RabbitMQ Server
+class ConsumeMessage:
 
-    :param queue: RabbitMQ Queue
-    :param exchange: RabbitMQ Exchange
-    :return: Wrapped User Function
-    :rtype: Function
+    def __init__(self, consume_queue: str, publish_queues: Union[str, List[str]] = None, exchange: str = '',
+                 production_ready: bool = True, logging: bool = True, logging_queue: str = 'logging'):
+        self._consume_queue = consume_queue
+        self._publish_queues = publish_queues
+        self._exchange = exchange
+        self._production_ready = production_ready
+        self._logging = logging
+        self._logging_queue = logging_queue
+        self._manager = PikachuStateManager()
 
-    """
-    def inner_function(func):
-        def prepare_channel(*args, **kwargs) -> NoReturn:
-            """
-            Run the function as expected but the return from the function must
-            be a Python dictionary as it will be converted to JSON. Then ensure
-            RabbitMQ connection is open and that you have an open channel.  Then
-            use a basic_publish method to send the message to the target queue.
-
-            :param args:  Any positional arguments passed to the function
-            :param kwargs: Any keyword arguments pass to the function
-            :return: None
-
-            """
-
-            # Run the function and get dictionary as result
-            result = func(*args, **kwargs)
-
-            # Ensure open connection and channel
-            _check_connection()
-
-            # Ensure queue exists
-            _CHANNEL.queue_declare(queue=queue)
-
-            # Send message to queue
-            _CHANNEL.basic_publish(
-                exchange=exchange,
-                routing_key=queue,
-                body=json.dumps(result)
-            )
-
-        return prepare_channel
-    return inner_function
-
-
-def consume_message(consume_queue: str, publish_queues: Union[str, List[str]] = None, exchange: str = '',
-                    production_ready: bool = True, logging: bool = True, logging_queue: str = 'logging') -> Any:
-    """
-    Receive messages from RabbitMQ Server
-
-    :param consume_queue: The queue from which to receive messages
-    :param publish_queues: The queue(s) to send messages to
-    :param exchange: The exchange to target if any
-    :param production_ready: Keyword argument that will make this
-    decorator only return one message from the queue rather than listen
-    if set to False; default True
-    :param logging: Keyword arg that will determine if incoming messages are logged; default True
-    :param logging_queue: Keyword arg for the
-    :return: Wrapped User Function
-    :rtype: Function
-
-    """
-    def inner_function(func):
-
-        def prepare_channel() -> Any:
+    def __call__(self, func, *args, **kwargs) -> Any:
+        def prepare_channel(*args, **kwargs):
             """
             Ensure RabbitMQ Connection is open and that you have an open
             channel.  Then provide a callback returns the target function
@@ -140,43 +78,78 @@ def consume_message(consume_queue: str, publish_queues: Union[str, List[str]] = 
 
             """
             # Open RabbitMQ connection if it has closed or is not set
-            _check_connection()
+            connection, channel = self._manager.ensure_connection_and_channel()
 
-            # Ensure the queue we want to write to has been created
-            _CHANNEL.queue_declare(queue=consume_queue)
+            log_publisher = PublishMessage(queue=self._logging_queue)
+            queue_publish = PublishMessage(queue=self._publish_queues, exchange=self._exchange)
 
             # Callback function for when a message is received
             def message_handler(channel, method, properties, body):
 
                 # Utilize module decorator to send logging messages
-                if logging:
-                    publish_message(queue=logging_queue)(send_log)(channel, method, properties, body)
+                if self._logging:
+                    log_publisher(queue=self._logging_queue)(send_log)(channel, method, properties, body)
 
-                if publish_queues:
-                    publish_message(queue=publish_queues, exchange=exchange)(func)(json.loads(body))
+                if self._publish_queues:
+                    queue_publish(queue=self._publish_queues, exchange=self._exchange)(func)(json.loads(body))
                 else:
                     func(json.loads(body))
 
             # Open up listener with callback
-            if production_ready:  # pragma: no cover
+            if self._production_ready:  # pragma: no cover
 
-                _CHANNEL.basic_consume(queue=consume_queue, on_message_callback=message_handler, auto_ack=True)
+                channel.basic_consume(queue=self._consume_queue, on_message_callback=message_handler, auto_ack=True)
 
                 try:
-                    _CHANNEL.start_consuming()
+                    channel.start_consuming()
                 except KeyboardInterrupt:
-                    _CHANNEL.stop_consuming()
+                    channel.stop_consuming()
 
             # Consume one message and stop listening
             else:
-                method, properties, body = _CHANNEL.basic_get(consume_queue, auto_ack=True)
-                method = str(method)
-                properties = str(properties)
+                method, properties, body = channel.basic_get(self._consume_queue, auto_ack=True)
 
                 if body:
                     message_handler(None, None, None, body)
-                    if logging:
-                        publish_message(queue=logging_queue)(send_log)(None, None, None, body)
+                    if self._logging:
+                        publish_message(queue=self._logging_queue)(send_log)(None, None, None, body)
 
         return prepare_channel
-    return inner_function
+
+
+class PublishMessage:
+
+    def __init__(self, queue: str, exchange: str = ''):
+        self._queue = queue
+        self._exchange = exchange
+        self._manager = PikachuStateManager()
+
+    def __call__(self, func, *args, **kwargs) -> Any:
+        def wrapper(*args, **kwargs):
+            """
+            Run the function as expected but the return from the function must
+            be a Python dictionary as it will be converted to JSON. Then ensure
+            RabbitMQ connection is open and that you have an open channel.  Then
+            use a basic_publish method to send the message to the target queue.
+
+            :param args:  Any positional arguments passed to the function
+            :param kwargs: Any keyword arguments pass to the function
+            :return: None
+
+            """
+            # Run the function and get dictionary as result
+            result = func(*args, **kwargs)
+
+            # Ensure open connection and channel
+            connection, channel = self._manager.ensure_connection_and_channel()
+
+            # Ensure queue exists
+            channel.queue_declare(queue=self._queue)
+
+            # Send message to queue
+            channel.basic_publish(
+                exchange=self._exchange,
+                routing_key=self._queue,
+                body=json.dumps(result)
+            )
+        return wrapper

--- a/rabbit_clients/clients/state_manager.py
+++ b/rabbit_clients/clients/state_manager.py
@@ -1,0 +1,64 @@
+"""
+Connection and channel management classes
+
+"""
+import os
+from typing import Tuple
+
+import pika
+
+
+class PikachuStateManager:
+    """
+    PikachuStateManager's sole purpose is to track RabbitMQ connection
+    and channel state to determine if a new connection or channel
+    is needed upon decorator call in rabbit clients.  TL;DR it's
+    an over-glorified tracking system so that I don't have
+    global variables all over the place.
+
+    :param username: RabbitMQ user that can publish and consume from connection credentials provided as **kwargs
+    :param pw: RabbitMQ user that can publish and consume from connection credentials proavided as **kwargs
+    :param `**kwargs`: All keywords are identical to those in pika.ConnectionParamters object.  See https://pika.readthedocs.io/en/stable/modules/parameters.html
+
+    """
+
+    def __init__(self, username: str = 'ENV', pw: str = 'ENV', **kwargs):
+        _username = username if not 'ENV' else os.getenv('RABBIT_USER', 'guest')
+        _pw = pw if not 'ENV' else os.getenv('RABBIT_PW', 'guest')
+        kwargs['credentials'] = pika.PlainCredentials(_username, _pw)
+        self._connect_params = pika.ConnectionParameters(**kwargs)
+        self._connection, self._channel = self.create_connection_and_channel()
+
+    def connection_and_channel_are_stable(self) -> Tuple[bool, bool]:
+        """
+        indicate whether the class should handle a new connection and/or channel
+
+        :return: A tuple with element zero indicating whether the connection is open and element two being the channel
+        :rtype: bool
+        """
+        return self._connection.is_open, self._channel.is_open
+
+    def create_connection_and_channel(self) -> Tuple[pika.BlockingConnection,
+                                                     pika.BlockingConnection.channel]:
+        """
+        Create a connection and channel for use
+
+        :return: Connection and Channel Pika objects
+
+        """
+        connection = pika.BlockingConnection(self._connect_params)
+        channel = connection.channel()
+        return connection, channel
+
+    def ensure_connection_and_channel(self) -> Tuple[pika.BlockingConnection,
+                                                     pika.BlockingConnection.channel]:
+        """
+        Check if the connection and/or channel are down.  Return current if not else return a new connection
+        and channel
+
+        :return: Connection and Channel pika objects
+
+        """
+        if not any(self.connection_and_channel_are_stable()):
+            return self.create_connection_and_channel()
+        return self._connection, self._connection.channel()

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -9,7 +9,7 @@ from typing import Dict, NoReturn, Any
 import time
 import os
 
-from rabbit_clients import publish_message, consume_message
+from rabbit_clients import publish_message, consume_message, PublishMessage
 
 
 _DOCKER_UP = os.environ['DOCKER_STATUS']
@@ -22,7 +22,7 @@ def test_that_a_message_is_sent_and_received() -> NoReturn:
 
     :return: None
     """
-    @publish_message(queue='test', exchange='')
+    @PublishMessage(queue='test', exchange='')
     def issue_message() -> Dict[str, str]:
         return {'lastName': 'Suave', 'firstName': 'Rico', 'call': 'oi-yaaay, oi-yay'}
 
@@ -43,7 +43,7 @@ def test_that_received_messages_are_published_to_logging_queue() -> NoReturn:
     :return: None
 
     """
-    @publish_message(queue='test', exchange='')
+    @PublishMessage(queue='test', exchange='')
     def issue_message() -> Dict[str, str]:
         return {'lastName': 'Suave', 'firstName': 'Rico', 'call': 'oi-yaaay, oi-yay'}
 


### PR DESCRIPTION
Do this as it is more efficient to maintain the RabbitMQ state in a simple class object