### PR TITLE
Breaking release to focus on base functionality

### DIFF
--- a/rabbit_clients/clients/base.py
+++ b/rabbit_clients/clients/base.py
@@ -88,10 +88,10 @@ class ConsumeMessage:
 
                 # Utilize module decorator to send logging messages
                 if self._logging:
-                    log_publisher(queue=self._logging_queue)(send_log)(channel, method, properties, body)
+                    log_publisher(send_log)(channel, method, properties, body)
 
                 if self._publish_queues:
-                    queue_publish(queue=self._publish_queues, exchange=self._exchange)(func)(json.loads(body))
+                    queue_publish(func)(json.loads(body))
                 else:
                     func(json.loads(body))
 
@@ -112,13 +112,12 @@ class ConsumeMessage:
                 if body:
                     message_handler(None, None, None, body)
                     if self._logging:
-                        publish_message(queue=self._logging_queue)(send_log)(None, None, None, body)
+                        PublishMessage(queue=self._logging_queue)(send_log)(None, None, None, body)
 
         return prepare_channel
 
 
 class PublishMessage:
-
     def __init__(self, queue: str, exchange: str = ''):
         self._queue = queue
         self._exchange = exchange

--- a/rabbit_clients/clients/state_manager.py
+++ b/rabbit_clients/clients/state_manager.py
@@ -26,6 +26,8 @@ class PikachuStateManager:
         _username = username if not 'ENV' else os.getenv('RABBIT_USER', 'guest')
         _pw = pw if not 'ENV' else os.getenv('RABBIT_PW', 'guest')
         kwargs['credentials'] = pika.PlainCredentials(_username, _pw)
+        kwargs['host'] = os.getenv('RABBIT_URL', 'localhost')
+        kwargs['heartbeat'] = 0
         self._connect_params = pika.ConnectionParameters(**kwargs)
         self._connection, self._channel = self.create_connection_and_channel()
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='rabbit-clients',
-    version='0.9.7',
+    version='1.0.4',
     packages=['tests', 'rabbit_clients', 'rabbit_clients.clients'],
     url='https://github.com/awburgess/rabbit-clients',
     license='MIT License',


### PR DESCRIPTION
### Issue Statement

The library was never fully completed and was trying to do more than was necessary in some cases.

### What changed?

- [x] Consumer and Publisher decorators are completely decoupled
- [x] Using ```retry``` library rather than reinvent wheel

### Define Done

- [x] The two features, decorating a function to publish a message or consume a message, are all it does and are functional