### PR TITLE
Added better exchange support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,7 @@ from setuptools import setup
 
 setup(
     name='rabbit-clients',
-<<<<<<< HEAD
-    version='2.0.0',
-=======
-    version='1.0.4',
->>>>>>> master
+    version='2.1.0',
     packages=['tests', 'rabbit_clients', 'rabbit_clients.clients'],
     url='https://github.com/awburgess/rabbit-clients',
     license='MIT License',


### PR DESCRIPTION
### Why

Do this because 2.0.0 focused on queues without appropriate exchange_declare or bindings

### What Changed?

- [x] Handling for when an exchange is declared to ensure follows protocol

### Define done

- [x] A user can submit an Exchange and expect that the queue argument will become the record key